### PR TITLE
Add initial code of conduct.

### DIFF
--- a/README.md.txt
+++ b/README.md.txt
@@ -1,0 +1,68 @@
+# Kalispell Software Crafters Code of Conduct
+
+Below are several versions of our code of conduct. These range from short, medium, and long versions which can be used for various media. This anti-harassment policy is based on the example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers. 
+
+## Short version
+
+Kalispell Software Crafters is dedicated to a harassment-free experience for everyone. Our anti-harassment policy can be found at: 
+
+https://github.com/kalispell-software-crafters/code-of-conduct
+
+## Medium version
+
+Kalispell Software Crafters is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any event venue, including presentations. Participants violating these rules may be sanctioned or expelled from the group (without a refund if applicable) at the discretion of the event and meetup organizers. Our anti-harassment policy can be found at: 
+
+https://github.com/kalispell-software-crafters/code-of-conduct
+
+## Long version
+
+Kalispell Software Crafters is dedicated to providing a harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age or religion. We do not tolerate harassment of participants in any form. Sexual language and imagery is not appropriate for any event venue, including presentations. Participants violating these rules may be sanctioned or expelled from the group (without a refund if applicable) at the discretion of the event and meetup organizers.
+
+Harassment includes, but is not limited to:
+
+* Verbal comments that reinforce social structures of domination (related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion).
+* Sexual images in public spaces
+* Deliberate intimidation, stalking, or following 
+* Harassing photography or recording
+* Sustained disruption of talks or other events
+* Inappropriate physical contact
+* Unwelcome sexual attention
+* Advocating for, or encouraging, any of the above behaviour 
+
+### Enforcement
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant engages in harassing behaviour, event organisers retain the right to take any actions to keep the event a welcoming environment for all participants. This includes warning the offender or expulsion from the conference (with no refund if applicable). 
+
+Event organisers may take action to redress anything designed to, or with the clear impact of, disrupting the event or making the environment hostile for any participants. 
+
+We expect participants to follow these rules at all event venues and event-related social activities. We think people should follow these rules outside event activities too! 
+
+### Reporting
+
+If someone makes you or anyone else feel unsafe or unwelcome, please report it as soon as possible. Harassment and other code of conduct violations reduce the value of our event for everyone. We want you to be happy at our event. People like you make our event a better place. 
+
+You can make a report either personally or anonymously. 
+
+### Anonymous Report
+
+You can make an anonymous report here https://kalispellsoftwarecrafters.wufoo.com/forms/kalispell-software-crafters-contact-form/. 
+
+We can't follow up an anonymous report with you directly, but we will fully investigate it and take whatever action is necessary to prevent a recurrence. 
+
+### Personal Report
+
+You can make a personal report by: 
+
+* Emailing us at kalispell.software.crafters AT gmail DOT com.
+* Contacting an event or meetup organizer, identified on our meetup page at https://www.meetup.com/Kalispell-Software-Crafters/members/?op=leaders. 
+
+When taking a personal report, our staff will ensure you are safe and cannot be overheard. They may involve other event staff to ensure your report is managed properly. Once safe, we'll ask you to tell us about what happened. This can be upsetting, but we'll handle it as respectfully as possible, and you can bring someone to support you. You won't be asked to confront anyone and we won't tell anyone who you are. 
+
+Our team will be happy to help you contact venue security, local law enforcement, local support services, provide escorts, or otherwise assist you to feel safe for the duration of the event. We value your attendance. 
+
+Local law enforcement: Kalispell City Police Department - (406) 758-7780 
+Local sexual assault hot line: The Abbie Shelter and Violence Free Crisis Line - (406) 752-7273
+Urgent care: Family Health Care - (406) 752-8120 
+Local taxi company: Glacier Taxi - (406) 250-3603


### PR DESCRIPTION
This PR adds our initial code of conduct.

This anti-harassment policy is based on the example policy from the Geek Feminism wiki, created by the Ada Initiative and other volunteers: https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy